### PR TITLE
Add espanso, rime, and mac config backup scripts

### DIFF
--- a/scripts/dot-backup.sh
+++ b/scripts/dot-backup.sh
@@ -1,7 +1,28 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Backup Brewfile
-brew bundle dump --force --file=~/dotfiles/scripts/Brewfile --describe
+mkdir -p "$HOME/dotfiles/scripts"
+brew bundle dump --force --file="$HOME/dotfiles/scripts/Brewfile" --describe
 
 # Backup Karabiner
-cp ~/.config/karabiner/karabiner.json ~/dotfiles/mac/karabiner.json
+mkdir -p "$HOME/dotfiles/mac"
+cp "$HOME/.config/karabiner/karabiner.json" "$HOME/dotfiles/mac/karabiner.json"
+
+# Backup Karabiner rules
+mkdir -p "$HOME/dotfiles/mac/karabiner-rules"
+cp "$HOME/.config/karabiner/assets/complex_modifications"/*.json \
+  "$HOME/dotfiles/mac/karabiner-rules/"
+
+# Backup Espanso configs
+mkdir -p "$HOME/dotfiles/espanso"
+cp -R "$HOME/Library/Application Support/espanso"/* "$HOME/dotfiles/espanso/"
+
+# Backup Rime configs
+mkdir -p "$HOME/dotfiles/rime"
+cp "$HOME/Library/Rime"/*.yaml "$HOME/dotfiles/rime/"
+
+# Backup Rectangle configuration
+mkdir -p "$HOME/dotfiles/mac"
+cp "$HOME/Library/Application Support/com.knollsoft.Rectangle"/*.json \
+  "$HOME/dotfiles/mac/RectangleConfig.json"

--- a/scripts/dot-restore.sh
+++ b/scripts/dot-restore.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Restore Espanso configs
+mkdir -p "$HOME/Library/Application Support/espanso"
+cp -R "$HOME/dotfiles/espanso"/* "$HOME/Library/Application Support/espanso/"
+
+# Restore Rime configs
+mkdir -p "$HOME/Library/Rime"
+cp "$HOME/dotfiles/rime"/*.yaml "$HOME/Library/Rime/"
+
+# Restore Rectangle configuration
+mkdir -p "$HOME/Library/Application Support/com.knollsoft.Rectangle"
+cp "$HOME/dotfiles/mac/RectangleConfig.json" \
+  "$HOME/Library/Application Support/com.knollsoft.Rectangle/"
+
+# Restore Karabiner rules
+mkdir -p "$HOME/.config/karabiner/assets/complex_modifications"
+cp "$HOME/dotfiles/mac/karabiner-rules"/*.json \
+  "$HOME/.config/karabiner/assets/complex_modifications/"


### PR DESCRIPTION
## Summary
- extend `dot-backup.sh` with additional macOS configuration backups
- add complementary `dot-restore.sh` script

## Testing
- `bash -n scripts/dot-backup.sh`
- `bash -n scripts/dot-restore.sh`


------
https://chatgpt.com/codex/tasks/task_e_6863601304288326ba0596e87c99c023